### PR TITLE
Fix error on Python 3.11

### DIFF
--- a/pyrtmp/amf/serializers.py
+++ b/pyrtmp/amf/serializers.py
@@ -120,7 +120,7 @@ class AMF0Deserializer:
         obj_type = data.read('uint:8')
         assert obj_type == AMF0.OBJECT
         obj = {}
-        ending = "0000{:02x}".format(AMF0.OBJECT_END)
+        ending = "0000{:02x}".format(int(AMF0.OBJECT_END))
         while data.peek('bytes:3').hex() != ending:
             # read property name
             size = data.read('uint:16')
@@ -136,7 +136,7 @@ class AMF0Deserializer:
         assert obj_type == AMF0.ARRAY
         arr = []
         count = data.read('uint:32')
-        ending = "0000{:02x}".format(AMF0.OBJECT_END)
+        ending = "0000{:02x}".format(int(AMF0.OBJECT_END))
         while data.peek('bytes:3').hex() != ending:
             size = data.read('uint:16')
             property_name = data.read(f'bytes:{size}').decode()


### PR DESCRIPTION
Due to a change in the Enum specification in Python 3.11, the following code will cause an error:

```py
from enum import Enum

# pyrtmp/amf/types.py
class AMF0(int, Enum):
    NUMBER = 0x00
    BOOLEAN = 0x01
    STRING = 0x02
    OBJECT = 0x03
    NULL = 0x05
    ARRAY = 0x08
    OBJECT_END = 0x09

# pyrtmp/amf/serializers.py
"0000{:02x}".format(AMF0.OBJECT_END)
```

```
>>> "0000{:02x}".format(AMF0.OBJECT_END)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.11/enum.py", line 1227, in __format__
    return str.__format__(str(self), format_spec)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: Unknown format code 'x' for object of type 'str'
```

This patch fixes the problem by first casting the value of AMF0 to int.
