### PR TITLE
Fixing breaking bitstring import

### DIFF
--- a/pyrtmp/__init__.py
+++ b/pyrtmp/__init__.py
@@ -5,7 +5,8 @@ from asyncio import StreamReader, StreamWriter, AbstractEventLoop, \
 from io import BytesIO
 from typing import Any, List, Optional, Mapping
 
-from bitstring import tokenparser, BitStream
+from bitstring import BitStream
+from bitstring.bitstream import tokenparser
 
 
 def random_byte_array(size: int) -> bytes:


### PR DESCRIPTION
# Fixing breaking bitstring import
## Situation
The library was unable to be used in python 3.x environments. 

## Reproduction 
- Paste example into main.py (Issue with port in serve_rtmp is not being fixed in this PR) 
- Create Dockerfile:
```
FROM python:3-alpine

RUN mkdir -p /application 

WORKDIR /application
COPY . /application/

RUN python -m pip install --upgrade pip && \
    apk add git build-base linux-headers
RUN --mount=type=cache,target=~/.cache/pip pip install -r requirements.txt

ENTRYPOINT [ "python", "main.py" ]
```
- Build image
- Run container

## Fix
Change: 
``` 
from bitstring import tokenparser, BitStream
``` 
To: 
``` 
from bitstring import BitStream 
from bitstring.bitstream import tokenparser
```

Tested in: 
Python 3.10 on Alpine 3.18
DEBUG set to True and False checked.

To test, simply replace the `pyrtmp==0.2.0` in the `requirements.txt` by `pyrtmp @ git+https://github.com/KneeNinetySeven/pyrtmp` 