### PR TITLE
Bug fixes in handling IPv6 addresses and multiple server sockets.

### DIFF
--- a/pyrtmp/rtmp.py
+++ b/pyrtmp/rtmp.py
@@ -15,6 +15,7 @@ from pyrtmp.messages.protocol_control import SetChunkSize, SetPeerBandwidth, Win
 from pyrtmp.messages.user_control import StreamBegin
 from pyrtmp.messages.video import VideoMessage
 from pyrtmp.session_manager import SessionManager
+from pyrtmp.utils import net_addr_to_string
 
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
@@ -202,10 +203,11 @@ class SimpleRTMPServer:
         )
 
     async def start(self) -> None:
+        addrs = ', '.join(net_addr_to_string(sock.family, sock.getsockname()) for sock in self.server.sockets)
         addr = self.server.sockets[0].getsockname()
         await self.server.start_serving()
         self._signal_on_start()
-        logger.info(f"Serving on {addr}")
+        logger.info(f"Serving on {addrs}")
 
     async def wait_closed(self) -> None:
         await self.server.wait_closed()

--- a/pyrtmp/session_manager.py
+++ b/pyrtmp/session_manager.py
@@ -8,6 +8,7 @@ from bitstring import BitStream
 from pyrtmp import BitStreamReader, random_byte_array
 from pyrtmp.messages import Chunk, RawChunk
 from pyrtmp.messages.handshake import C0, C1, C2
+from pyrtmp.utils import net_addr_to_string
 
 
 class SessionManager:
@@ -30,8 +31,8 @@ class SessionManager:
 
     @property
     def peername(self) -> str:
-        a, b = self.writer.get_extra_info("peername")
-        return f"{a}:{b}"
+        s = self.writer.get_extra_info("socket")
+        return net_addr_to_string(s.family, s.getpeername())
 
     def set_latest_chunk(self, chunk: RawChunk) -> None:
         self.latest_chunks[str(chunk.chunk_id)] = chunk

--- a/pyrtmp/utils.py
+++ b/pyrtmp/utils.py
@@ -1,0 +1,12 @@
+import socket
+
+
+def net_addr_to_string(family, addr):
+    if s.family == socket.AF_INET:
+        return f"{addr[0]}:{addr[1]}"
+
+    elif s.family == socket.AF_INET6:
+        return f"[{addr[0]}]:{addr[1]}"
+
+    return str(addr)
+


### PR DESCRIPTION
Currently session_manager.SessionManager.peername has a bug because for IPv6 sockets the address returned is a tuple of 4 values, not two. For UNIX sockets it is just a string. This patch fixes all these issues. It also prints exactly what addresses the server is listening on at startup, rather than just the first one.