### PR TITLE
Move basicConfig into run as main section

### DIFF
--- a/pyrtmp/rtmp.py
+++ b/pyrtmp/rtmp.py
@@ -16,7 +16,6 @@ from pyrtmp.messages.user_control import StreamBegin
 from pyrtmp.messages.video import VideoMessage
 from pyrtmp.session_manager import SessionManager
 
-logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
@@ -223,4 +222,5 @@ async def main() -> None:
 
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.DEBUG)
     asyncio.run(main())


### PR DESCRIPTION
Modules should not run `logging.basicConfig()` in the root of the module, because this affects any applications that import the module. Move this line under `if __name__ == "__main__":` so this does not happen any more.